### PR TITLE
Only handle GA authentication on the defined redirect URI

### DIFF
--- a/hm-top-posts.php
+++ b/hm-top-posts.php
@@ -151,13 +151,18 @@ class HMTP_Plugin {
 	 * @todo nonce
 	 */
 	public function init() {
+		global $wp;
 
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
 
+		// Check that this is a redirect response from GA - ie that it matches
+		// the ga_redirect_uri setting.
+		$current_request = home_url( $wp->request );
+
 		// Authenticate.
-		if ( isset( $_GET['code'] ) ) {
+		if ( isset( $_GET['code'] ) && $current_request === $this->settings['ga_redirect_uri'] ) {
 
 			$this->ga_client->authenticate();
 			update_option( 'hmtp_ga_token', $this->ga_client->getAccessToken() );


### PR DESCRIPTION
This plugin was trying to perform oAuth authentication with Google anytime it received a URL containing the query string '?code='. In addition to breaking any other oauth integrations on a site, this just seems like a bad idea, open to DDOS and other abuse.

This commit checks to make sure that the oauth handshake only happens on the page defined as the "ga_redirect_uri" in plugin settings - ideally, this would be an admin page to prevent abuse.