### PR TITLE
Fix PHP 7.4 warnings

### DIFF
--- a/google-api-php-client/src/io/Google_REST.php
+++ b/google-api-php-client/src/io/Google_REST.php
@@ -120,7 +120,7 @@ class Google_REST {
     $requestUrl = str_replace('%40', '@', $requestUrl);
 
     if (count($queryVars)) {
-      $requestUrl .= '?' . implode($queryVars, '&');
+      $requestUrl .= '?' . implode('&', $queryVars);
     }
 
     return $requestUrl;

--- a/google-api-php-client/src/service/Google_Utils.php
+++ b/google-api-php-client/src/service/Google_Utils.php
@@ -55,7 +55,7 @@ class Google_Utils {
     $strlenVar = strlen($str);
     $d = $ret = 0;
     for ($count = 0; $count < $strlenVar; ++ $count) {
-      $ordinalValue = ord($str{$ret});
+      $ordinalValue = ord($str[$ret]);
       switch (true) {
         case (($ordinalValue >= 0x20) && ($ordinalValue <= 0x7F)):
           // characters U-00000000 - U-0000007F (same as ASCII)


### PR DESCRIPTION
This PR addresses two issues flagged by running 
```
phpcs -p . --standard=PHPCompatibility --extensions=php --runtime-set testVersion 7.4
```
on this repository's `refactor` branch. While somewhat outdated it seems to continue to work, but the Google client triggers PHP warnings. These two minor adjustments resolve the issue.